### PR TITLE
explicitly open version.py in setup.py using UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ def read(fname):
 
 # Version info -- read without importing
 _LOCALS = {}
-with open(os.path.join(SETUP_DIRNAME, 'pytest_logging', 'version.py')) as rfh:
+with open(os.path.join(SETUP_DIRNAME, 'pytest_logging', 'version.py'),
+          encoding='utf-8') as rfh:
     exec(rfh.read(), None, _LOCALS)  # pylint: disable=exec-used
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ def read(fname):
 
 # Version info -- read without importing
 _LOCALS = {}
-with open(os.path.join(SETUP_DIRNAME, 'pytest_logging', 'version.py'),
-          encoding='utf-8') as rfh:
+with codecs.open(os.path.join(SETUP_DIRNAME, 'pytest_logging', 'version.py'),
+                 encoding='utf-8') as rfh:
     exec(rfh.read(), None, _LOCALS)  # pylint: disable=exec-used
 
 


### PR DESCRIPTION
Otherwise setup.py will fail to run on environments with non-UTF-8 default encoding (e.g. in Docker container based on "ubuntu.xenial" image) with error like following:

```
Collecting git+https://github.com/saltstack/pytest-logging
  Cloning https://github.com/saltstack/pytest-logging to /tmp/pip-hztxqe9x-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-hztxqe9x-build/setup.py", line 34, in <module>
        exec(rfh.read(), None, _LOCALS)  # pylint: disable=exec-used
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 105: ordinal not in range(128)
```