### PR TITLE
Add entry point prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     ],
     entry_points={
         'pytest11': [
-            'logging = pytest_logging.plugin',
+            'pytest_logging = pytest_logging.plugin',
         ],
     },
 )


### PR DESCRIPTION
Update the entry point for correct work in the latest versions of pytest (3.3 and above). This is necessary to prevent a conflict with the default logging plugin